### PR TITLE
スマートフォン用サイトとタブレット以上の画面表示をメディアクエリで実装

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -45,11 +45,11 @@
                     <form action="mailTo.php">
                         <dl>
                             <dt>お名前</dt>
-                            <dd><input type="text"></dd>
+                            <dd><input type="text" name="fullName"></dd>
                             <dt>メールアドレス</dt>
-                            <dd><input type="text" name="" id=""></dd>
+                            <dd><input type="text" name="email"></dd>
                             <dt>メッセージ</dt>
-                            <dd><textarea name="" id="" cols="30" rows="10"></textarea></dd>
+                            <dd><textarea name="message" cols="30" rows="4"></textarea></dd>
                         </dl>
                         <input type="submit" value="送信">
                     </form>

--- a/contact.html
+++ b/contact.html
@@ -27,16 +27,18 @@
     <div class="container">
 
         <header class="contactHeaderBox">
-            <div class="logo">
-                <a href="index.html"><img src="src/image/logo.svg" alt="logo"></a>
+            <div class="generalNavigation">
+                <div class="logo">
+                    <a href="index.html"><img src="src/image/logo.svg" alt="logo"></a>
+                </div>
+                <nav>
+                    <ul>
+                        <a href="news.html"><li>NEWS</li></a>
+                        <a href="menu.html"><li>MENU</li></a>
+                        <a href="contact.html"><li>CONTACT</li></a>
+                    </ul>
+                </nav>
             </div>
-            <nav>
-                <ul>
-                    <a href="news.html"><li>NEWS</li></a>
-                    <a href="menu.html"><li>MENU</li></a>
-                    <a href="contact.html"><li>CONTACT</li></a>
-                </ul>
-            </nav>
             <div class="contactTop">
                 <h2>CONTACT</h2>
                 <section class="mailForm">

--- a/contact.html
+++ b/contact.html
@@ -72,30 +72,32 @@
                     <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3241.849815273872!2d139.7024803153445!3d35.65607168020017!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x60188b5bc514d2f1%3A0x321a30f46b63125a!2z44CSMTUwLTAwMDIg5p2x5Lqs6YO95riL6LC35Yy65riL6LC377yT5LiB55uu77yS77yX4oiS77yR77yV!5e0!3m2!1sja!2sjp!4v1585030086808!5m2!1sja!2sjp" width="100%" height="490px" frameborder="0" style="border:0;" aria-hidden="false" tabindex="0"></iframe>
                 </div>
             </section>
-            <section class="mediaBox">
-                <div class="facebookBox">
-                    <h3>Facebook</h3>
-                    <div class="frameBox">
-                        <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fm.facebook.com%2Fgiftedacademy.tokyo%2F&tabs=timeline&width=342&height=456&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId" width="342" height="456" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
-                    </div>
-                </div>
-                <div class="twitterBox">
-                    <h3>Twitter</h3>
-                    <div class="frameBox">
-                        <a class="twitter-timeline" data-width="342" data-height="456" href="https://twitter.com/gftd_works?ref_src=twsrc%5Etfw">Tweets by gftd_works</a>
-                        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-                    </div>
-                </div>
-                <div class="youtubeBox">
-                    <h3>youtube</h3>
-                    <div class="frameBox">
-                        <iframe width="342" height="456" src="https://www.youtube.com/embed/S-HmZp4aOQ8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                    </div>
-                </div>
-            </section>
         </main>
 
         <footer>
+            <div class="footerMedia">
+                <section class="mediaBox">
+                    <div class="facebookBox">
+                        <h3>Facebook</h3>
+                        <div class="frameBox">
+                            <iframe src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fm.facebook.com%2Fgiftedacademy.tokyo%2F&tabs=timeline&width=342&height=456&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true&appId" width="342" height="456" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe>
+                        </div>
+                    </div>
+                    <div class="twitterBox">
+                        <h3>Twitter</h3>
+                        <div class="frameBox">
+                            <a class="twitter-timeline" data-width="342" data-height="456" href="https://twitter.com/gftd_works?ref_src=twsrc%5Etfw">Tweets by gftd_works</a>
+                            <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+                        </div>
+                    </div>
+                    <div class="youtubeBox">
+                        <h3>youtube</h3>
+                        <div class="frameBox">
+                            <iframe width="342" height="456" src="https://www.youtube.com/embed/S-HmZp4aOQ8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                        </div>
+                    </div>
+                </section>
+            </div>
             <p><small>&copy; 2020 GFTD.WORKS</small></p>
         </footer>
 

--- a/css/style.css
+++ b/css/style.css
@@ -322,25 +322,34 @@ header.menuHeaderBox .menuTop {
 .menuHeaderBox .menuTop p {
     margin: 20px 15px 0;
 }
-@media screen and (min-width:320px) {
+@media screen and (min-width:320px) and (max-width:767px) {
     main.menuContainer {
         padding: 10px;
         display: flex;
         flex-direction: column;
+    }
+    .menuContainer figure.gridBox {
+        margin-bottom: 20px;
     }
 }
 @media screen and (min-width:768px) {
     main.menuContainer {
         padding: 10px;
         display: grid;
+        grid-template-rows: 25% 25% 25% 25%;
+        grid-template-columns: 33% 33% 33%;
     }
-}
-.menuContainer figure.gridBox {
-    margin-bottom: 20px;
+    .menuContainer figure.gridBox:first-child {
+        grid-column: 1/3;
+        grid-row: 1/3;
+    }
+    .menuContainer figure.gridBox {
+        margin: 5px;
+    }
 }
 .menuContainer .gridBox img {
     width: 100%;
-    height: 100%;
+    height: auto;
 }
 .menuContainer .gridBox figcaption {
     font-size: small;

--- a/css/style.css
+++ b/css/style.css
@@ -414,6 +414,12 @@ main.contactContainer section.mapBox {
     background-color: #FBF7F1;
     padding: 10px 10px 50px;
 }
+@media screen and (min-width:1200px) {
+    .contactContainer section.mediaBox {
+        flex-direction: row;
+        justify-content: space-between;
+    }
+}
 .contactContainer .mediaBox div.frameBox {
     margin: 10px 0;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -54,14 +54,14 @@ h3 {
 }
 
 /* header共通 */
-@media screen and (min-width:320px) {
-div.container header[class*=HeaderBox] {
+@media screen and (min-width:320px) {  /* モバイルファースト */
+div.container header[class*=HeaderBox] div.generalNavigation {
     display: flex;
     flex-direction: column;
 }
 }
-@media screen and (min-width:768px) {
-div.container header[class*=HeaderBox] {
+@media screen and (min-width:768px) {  /* タブレット以上 */
+div.container header[class*=HeaderBox] div.generalNavigation {
     display: flex;
     flex-direction: row;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -54,26 +54,38 @@ h3 {
 }
 
 /* header共通 */
-header .logo {  /* logoのボックスサイズ */
+@media screen and (min-width:320px) {
+div.container header[class*=HeaderBox] {
+    display: flex;
+    flex-direction: column;
+}
+}
+@media screen and (min-width:768px) {
+div.container header[class*=HeaderBox] {
+    display: flex;
+    flex-direction: row;
+}
+}
+header[class*=HeaderBox] .logo {  /* logoのボックスサイズ */
     width: 200px;
     height: auto;
     margin: 0 auto;
 }
-header .logo img {  /* logoのイメージサイズは'div class=logo'に依存 */
+header[class*=HeaderBox] .logo img {  /* logoのイメージサイズは'div class=logo'に依存 */
     width: 100%;
     height: 100%;
 }
-header nav {
+header[class*=HeaderBox] nav {
     width: 100%;
 }
-header nav ul {
+header[class*=HeaderBox] nav ul {
     display: flex;
     justify-content: center;
 }
-header nav ul li {
+header[class*=HeaderBox] nav ul li {
     margin: 10px 20px;
 }
-header h2 {  /* indexは該当タグ無し */
+header[class*=HeaderBox] h2 {  /* indexは該当タグ無し */
     text-align: center;
     font-family: 'Philosopher', sans-serif;
     font-weight: 400;

--- a/css/style.css
+++ b/css/style.css
@@ -44,7 +44,6 @@ footer {
 }
 }
 
-
 /* 全体共通部品 */
 body {
     font-size: 100%;
@@ -323,9 +322,18 @@ header.menuHeaderBox .menuTop {
 .menuHeaderBox .menuTop p {
     margin: 20px 15px 0;
 }
+@media screen and (min-width:320px) {
+main.menuContainer {
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+}
+}
+@media screen and (min-width:768px) {
 main.menuContainer {
     padding: 10px;
     display: grid;
+}
 }
 .menuContainer figure.gridBox {
     margin-bottom: 20px;

--- a/css/style.css
+++ b/css/style.css
@@ -216,14 +216,29 @@ main.indexBox {
 header.newsHeaderBox .newsTop {
     margin: 30px 0 50px;
 }
+@media screen and (min-width:320px) {
 main.newsContainer {
     padding: 40px 10px;
     display: flex;
     flex-direction: column;
 }
+}
+@media screen and (min-width:768px) {
+main.newsContainer {
+    padding: 40px 10px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+}
 .newsContainer article.articleBox {
     display: flex;
     flex-direction: column;
+}
+@media screen and (min-width:768px) {
+.newsContainer article.articleBox {
+    width: 60%;
+}
 }
 .newsContainer .articleBox header.articleHeader {
     display: flex;
@@ -270,7 +285,7 @@ main.newsContainer {
 }
 .newsContainer .articleContents img {
     width: 100%;
-    height: 100%;
+    height: auto;
     margin: 10px 0;
 }
 .newsContainer .articleContents p {
@@ -280,6 +295,11 @@ main.newsContainer {
     margin-top: 30px;
     display: flex;
     flex-direction: column;
+}
+@media screen and (min-width:768px) {
+.newsContainer aside.sidebarBox {
+    width: 35%;
+}
 }
 .newsContainer .sidebarBox section {
     margin: 15px 0;

--- a/css/style.css
+++ b/css/style.css
@@ -26,7 +26,7 @@ footer {
 }
 }
 @media screen and (min-width:768px) {
-header {  /* タブレット以上は80%まで */
+header>div {  /* タブレット以上は80%まで */
     width: 80%;
     margin: 0 auto;
 }
@@ -35,7 +35,7 @@ main {
     margin: 0 auto;
 }
 footer {
-    width: 80%;
+    width: 100%;
     margin: 0 auto;
 }
 }
@@ -71,6 +71,10 @@ h3 {
 }
 
 /* header共通 */
+div.container header[class*=HeaderBox] {
+    display: flex;
+    flex-direction: column;
+}
 @media screen and (min-width:320px) {  /* モバイルファースト */
 div.container header[class*=HeaderBox] div.generalNavigation {
     display: flex;
@@ -98,6 +102,9 @@ header[class*=HeaderBox] .logo {  /* logoのボックスサイズ */
     width: 200px;
     height: auto;
     margin: 0 auto 0 0;
+}
+header div[class*=Top] {
+    align-self: center;
 }
 }
 header[class*=HeaderBox] .logo img {  /* logoのイメージサイズは'div class=logo'に依存 */

--- a/css/style.css
+++ b/css/style.css
@@ -385,12 +385,12 @@ header.contactHeaderBox div.contactTop {
         width: 50%;
     }
 }
-main.contactContainer section.mapBox {
+.contactContainer section.mapBox {
     padding: 10px;
     margin-bottom: 30px;
 }
 @media screen and (min-width:768px) {
-    main.contactContainer section.mapBox {
+    .contactContainer section.mapBox {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
@@ -402,28 +402,33 @@ main.contactContainer section.mapBox {
         width: 70%;
     }
 }
-.contactContainer section h3 {
+.contactContainer section h3,
+footer .footerMedia h3 {
     font-family: 'Noto Sans JP', sans-serif;
 }
 .contactContainer .mapBox aside div.storeInformation {
     padding: 10px;
 }
-.contactContainer section.mediaBox {
+footer div.footerMedia {
+    background-color: #FBF7F1;
+}
+footer div.footerMedia section.mediaBox {
     display: flex;
     flex-direction: column;
-    background-color: #FBF7F1;
     padding: 10px 10px 50px;
 }
 @media screen and (min-width:1200px) {
-    .contactContainer section.mediaBox {
+    footer div.footerMedia section.mediaBox {
         flex-direction: row;
         justify-content: space-between;
+        width: 80%;
+        margin: 0 auto;
     }
 }
-.contactContainer .mediaBox div.frameBox {
+.footerMedia .mediaBox div.frameBox {
     margin: 10px 0;
 }
-.contactContainer .mediaBox>div>div[class*=Box] {
+.footerMedia .mediaBox>div>div[class*=Box] {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/css/style.css
+++ b/css/style.css
@@ -240,7 +240,7 @@ header.newsHeaderBox .newsTop {
 }
 @media screen and (min-width:768px) {
     .newsContainer article.articleBox {
-        width: 60%;
+        width: 70%;
     }
 }
 .newsContainer .articleBox header.articleHeader {
@@ -301,7 +301,7 @@ header.newsHeaderBox .newsTop {
 }
 @media screen and (min-width:768px) {
     .newsContainer aside.sidebarBox {
-        width: 35%;
+        width: 25%;
     }
 }
 .newsContainer .sidebarBox section {
@@ -362,22 +362,45 @@ header.contactHeaderBox div.contactTop {
 .contactHeaderBox .contactTop h2 {
     text-align: left;
 }
-.contactHeaderBox .contactTop section.mailForm {
-    margin: 10px 0;
+@media screen and (min-width:320px) {
+    .contactHeaderBox .contactTop section.mailForm {
+        margin: 10px 0;
+    }
+    .contactHeaderBox .contactTop form dl>*{
+        margin-bottom: 10px;
+    }
+    .contactHeaderBox .contactTop form input[type=text],
+    .contactHeaderBox .contactTop form textarea {
+        border: #ffffff solid 1px;
+        border-radius: 5px;
+        background-color: rgba(255,255,255,0.5);
+        width: 100%;
+    }
 }
-.contactHeaderBox .contactTop form dl>*{
-    margin-bottom: 10px;
-}
-.contactHeaderBox .contactTop form input[type=text],
-.contactHeaderBox .contactTop form textarea {
-    border: #ffffff solid 1px;
-    border-radius: 5px;
-    background-color: rgba(255,255,255,0.5);
-    width: 100%;
+@media screen and (min-width:768px) {
+    .contactHeaderBox .contactTop form input[type=text] {
+        width: 25%;
+    }
+    .contactHeaderBox .contactTop form textarea {
+        width: 50%;
+    }
 }
 main.contactContainer section.mapBox {
     padding: 10px;
     margin-bottom: 30px;
+}
+@media screen and (min-width:768px) {
+    main.contactContainer section.mapBox {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+    aside {
+        width: 25%;
+    }
+    div.googleMap {
+        width: 70%;
+    }
 }
 .contactContainer section h3 {
     font-family: 'Noto Sans JP', sans-serif;

--- a/css/style.css
+++ b/css/style.css
@@ -11,6 +11,7 @@ body div.container {  /* container導入 */
     min-height: 100vh;
     align-items: center;
 }
+@media screen and (min-width:320px) {
 header {  /* 横枠を100％まで広がって自動で余白を取る */
     width: 100%;
     margin: 0 auto;
@@ -23,6 +24,22 @@ footer {
     width: 100%;
     margin: 0 auto;
 }
+}
+@media screen and (min-width:768px) {
+header {  /* タブレット以上は80%まで */
+    width: 80%;
+    margin: 0 auto;
+}
+main {
+    width: 80%;
+    margin: 0 auto;
+}
+footer {
+    width: 80%;
+    margin: 0 auto;
+}
+}
+
 
 /* 全体共通部品 */
 body {
@@ -59,24 +76,33 @@ div.container header[class*=HeaderBox] div.generalNavigation {
     display: flex;
     flex-direction: column;
 }
-}
-@media screen and (min-width:768px) {  /* タブレット以上 */
-div.container header[class*=HeaderBox] div.generalNavigation {
-    display: flex;
-    flex-direction: row;
-}
-}
 header[class*=HeaderBox] .logo {  /* logoのボックスサイズ */
     width: 200px;
     height: auto;
     margin: 0 auto;
 }
+}
+@media screen and (min-width:768px) {  /* タブレット以上 */
+div.container header[class*=HeaderBox] div.generalNavigation {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+.generalNavigation div.logo {
+    align-self: flex-start;
+}
+.generalNavigation nav {
+    align-self: flex-end;
+}
+header[class*=HeaderBox] .logo {  /* logoのボックスサイズ */
+    width: 200px;
+    height: auto;
+    margin: 0 auto 0 0;
+}
+}
 header[class*=HeaderBox] .logo img {  /* logoのイメージサイズは'div class=logo'に依存 */
     width: 100%;
     height: 100%;
-}
-header[class*=HeaderBox] nav {
-    width: 100%;
 }
 header[class*=HeaderBox] nav ul {
     display: flex;
@@ -143,12 +169,6 @@ header.contactHeaderBox {
 }
 
 /* index */
-main.indexBox {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin: 50px 0px;
-}
 .indexBox h2 {
     font-family: 'Philosopher', sans-serif;
     font-weight: 400;
@@ -157,9 +177,29 @@ main.indexBox {
     margin: 20px 0px;
     width: 90%;
 }
+@media screen and (min-width:320px) {
+main.indexBox {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 50px 0px;
+}
 .indexBox p {
     text-align: left;
     width: 90%;
+}
+}
+@media screen and (min-width:768px) {
+main.indexBox {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 200px 0px;
+}
+.indexBox p {
+    text-align: center;
+    width: 90%;
+}
 }
 .indexBox button {
     margin: 30px;

--- a/css/style.css
+++ b/css/style.css
@@ -12,36 +12,36 @@ body div.container {  /* container導入 */
     align-items: center;
 }
 @media screen and (min-width:320px) {
-header {  /* 横枠を100％まで広がって自動で余白を取る */
-    width: 100%;
-    margin: 0 auto;
-}
-main {
-    width: 100%;
-    margin: 0 auto;
-}
-footer {
-    width: 100%;
-    margin: 0 auto;
-}
+    header {  /* 横枠を100％まで広がって自動で余白を取る */
+        width: 100%;
+        margin: 0 auto;
+    }
+    main {
+        width: 100%;
+        margin: 0 auto;
+    }
+    footer {
+        width: 100%;
+        margin: 0 auto;
+    }
 }
 @media screen and (min-width:768px) {
-header>div {  /* タブレット以上は80%まで */
-    width: 80%;
-    margin: 0 auto;
-}
-header>div>div.sentence {
-    width: 60%;
-    margin: 0 auto;
-}
-main {
-    width: 80%;
-    margin: 0 auto;
-}
-footer {
-    width: 100%;
-    margin: 0 auto;
-}
+    header>div {  /* タブレット以上は80%まで */
+        width: 80%;
+        margin: 0 auto;
+    }
+    header>div>div.sentence {
+        width: 60%;
+        margin: 0 auto;
+    }
+    main {
+        width: 80%;
+        margin: 0 auto;
+    }
+    footer {
+        width: 100%;
+        margin: 0 auto;
+    }
 }
 
 /* 全体共通部品 */
@@ -79,36 +79,36 @@ div.container header[class*=HeaderBox] {
     flex-direction: column;
 }
 @media screen and (min-width:320px) {  /* モバイルファースト */
-div.container header[class*=HeaderBox] div.generalNavigation {
-    display: flex;
-    flex-direction: column;
-}
-header[class*=HeaderBox] .logo {  /* logoのボックスサイズ */
-    width: 200px;
-    height: auto;
-    margin: 0 auto;
-}
+    div.container header[class*=HeaderBox] div.generalNavigation {
+        display: flex;
+        flex-direction: column;
+    }
+    header[class*=HeaderBox] .logo {  /* logoのボックスサイズ */
+        width: 200px;
+        height: auto;
+        margin: 0 auto;
+    }
 }
 @media screen and (min-width:768px) {  /* タブレット以上 */
-div.container header[class*=HeaderBox] div.generalNavigation {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-}
-.generalNavigation div.logo {
-    align-self: flex-start;
-}
-.generalNavigation nav {
-    align-self: flex-end;
-}
-header[class*=HeaderBox] .logo {  /* logoのボックスサイズ */
-    width: 200px;
-    height: auto;
-    margin: 0 auto 0 0;
-}
-header div[class*=Top] {
-    align-self: center;
-}
+    div.container header[class*=HeaderBox] div.generalNavigation {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+    .generalNavigation div.logo {
+        align-self: flex-start;
+    }
+    .generalNavigation nav {
+        align-self: flex-end;
+    }
+    header[class*=HeaderBox] .logo {  /* logoのボックスサイズ */
+        width: 200px;
+        height: auto;
+        margin: 0 auto 0 0;
+    }
+    header div[class*=Top] {
+        align-self: center;
+    }
 }
 header[class*=HeaderBox] .logo img {  /* logoのイメージサイズは'div class=logo'に依存 */
     width: 100%;
@@ -188,28 +188,28 @@ header.contactHeaderBox {
     width: 90%;
 }
 @media screen and (min-width:320px) {
-main.indexBox {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin: 50px 0px;
-}
-.indexBox p {
-    text-align: left;
-    width: 90%;
-}
+    main.indexBox {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin: 50px 0px;
+    }
+    .indexBox p {
+        text-align: left;
+        width: 90%;
+    }
 }
 @media screen and (min-width:768px) {
-main.indexBox {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin: 200px 0px;
-}
-.indexBox p {
-    text-align: center;
-    width: 90%;
-}
+    main.indexBox {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin: 200px 0px;
+    }
+    .indexBox p {
+        text-align: center;
+        width: 90%;
+    }
 }
 .indexBox button {
     margin: 30px;
@@ -220,28 +220,28 @@ header.newsHeaderBox .newsTop {
     margin: 30px 0 50px;
 }
 @media screen and (min-width:320px) {
-main.newsContainer {
-    padding: 40px 10px;
-    display: flex;
-    flex-direction: column;
-}
+    main.newsContainer {
+        padding: 40px 10px;
+        display: flex;
+        flex-direction: column;
+    }
 }
 @media screen and (min-width:768px) {
-main.newsContainer {
-    padding: 40px 10px;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-}
+    main.newsContainer {
+        padding: 40px 10px;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+    }
 }
 .newsContainer article.articleBox {
     display: flex;
     flex-direction: column;
 }
 @media screen and (min-width:768px) {
-.newsContainer article.articleBox {
-    width: 60%;
-}
+    .newsContainer article.articleBox {
+        width: 60%;
+    }
 }
 .newsContainer .articleBox header.articleHeader {
     display: flex;
@@ -300,9 +300,9 @@ main.newsContainer {
     flex-direction: column;
 }
 @media screen and (min-width:768px) {
-.newsContainer aside.sidebarBox {
-    width: 35%;
-}
+    .newsContainer aside.sidebarBox {
+        width: 35%;
+    }
 }
 .newsContainer .sidebarBox section {
     margin: 15px 0;
@@ -323,17 +323,17 @@ header.menuHeaderBox .menuTop {
     margin: 20px 15px 0;
 }
 @media screen and (min-width:320px) {
-main.menuContainer {
-    padding: 10px;
-    display: flex;
-    flex-direction: column;
-}
+    main.menuContainer {
+        padding: 10px;
+        display: flex;
+        flex-direction: column;
+    }
 }
 @media screen and (min-width:768px) {
-main.menuContainer {
-    padding: 10px;
-    display: grid;
-}
+    main.menuContainer {
+        padding: 10px;
+        display: grid;
+    }
 }
 .menuContainer figure.gridBox {
     margin-bottom: 20px;

--- a/css/style.css
+++ b/css/style.css
@@ -30,6 +30,10 @@ header>div {  /* タブレット以上は80%まで */
     width: 80%;
     margin: 0 auto;
 }
+header>div>div.sentence {
+    width: 60%;
+    margin: 0 auto;
+}
 main {
     width: 80%;
     margin: 0 auto;

--- a/index.html
+++ b/index.html
@@ -27,16 +27,18 @@
     <div class="container">
 
         <header class="indexHeaderBox">
-            <div class="logo">
-                <a href="index.html"><img src="src/image/logo.svg" alt="logo"></a>
+            <div class="generalNavigation">
+                <div class="logo">
+                    <a href="index.html"><img src="src/image/logo.svg" alt="logo"></a>
+                </div>
+                <nav>
+                    <ul>
+                        <a href="news.html"><li>NEWS</li></a>
+                        <a href="menu.html"><li>MENU</li></a>
+                        <a href="contact.html"><li>CONTACT</li></a>
+                    </ul>
+                </nav>
             </div>
-            <nav>
-                <ul>
-                    <a href="news.html"><li>NEWS</li></a>
-                    <a href="menu.html"><li>MENU</li></a>
-                    <a href="contact.html"><li>CONTACT</li></a>
-                </ul>
-            </nav>
         </header>
 
         <main class="indexBox">

--- a/menu.html
+++ b/menu.html
@@ -41,9 +41,9 @@
             </div>
             <div class="menuTop">
                 <h2>MENU</h2>
-                <span class="sentence">
+                <div class="sentence">
                     <p>幸福ですか、市民。市民は幸福でなければいけません。あなたは市民ですか？市民の皆様はコンピューターへの奉仕が義務付けられています。理解できますね。あなたは市民ですか？</p>
-                </span>
+                </div>
             </div>
         </header>
 

--- a/menu.html
+++ b/menu.html
@@ -27,16 +27,18 @@
     <div class="container">
 
         <header class="menuHeaderBox">
-            <div class="logo">
-                <a href="index.html"><img src="src/image/logo.svg" alt="logo"></a>
+            <div class="generalNavigation">
+                <div class="logo">
+                    <a href="index.html"><img src="src/image/logo.svg" alt="logo"></a>
+                </div>
+                <nav>
+                    <ul>
+                        <a href="news.html"><li>NEWS</li></a>
+                        <a href="menu.html"><li>MENU</li></a>
+                        <a href="contact.html"><li>CONTACT</li></a>
+                    </ul>
+                </nav>
             </div>
-            <nav>
-                <ul>
-                    <a href="news.html"><li>NEWS</li></a>
-                    <a href="menu.html"><li>MENU</li></a>
-                    <a href="contact.html"><li>CONTACT</li></a>
-                </ul>
-            </nav>
             <div class="menuTop">
                 <h2>MENU</h2>
                 <span class="sentence">

--- a/news.html
+++ b/news.html
@@ -27,16 +27,18 @@
     <div class="container">
 
         <header class="newsHeaderBox">
-            <div class="logo">
-                <a href="index.html"><img src="src/image/logo.svg" alt="logo"></a>
+            <div class="generalNavigation">
+                <div class="logo">
+                    <a href="index.html"><img src="src/image/logo.svg" alt="logo"></a>
+                </div>
+                <nav>
+                    <ul>
+                        <a href="news.html"><li>NEWS</li></a>
+                        <a href="menu.html"><li>MENU</li></a>
+                        <a href="contact.html"><li>CONTACT</li></a>
+                    </ul>
+                </nav>
             </div>
-            <nav>
-                <ul>
-                    <a href="news.html"><li>NEWS</li></a>
-                    <a href="menu.html"><li>MENU</li></a>
-                    <a href="contact.html"><li>CONTACT</li></a>
-                </ul>
-            </nav>
             <div class="newsTop">
                 <h2>NEWS</h2>
             </div>


### PR DESCRIPTION
## 概要

**課題完了のご確認をお願いします**

- スマートフォン用ページのCSS装飾が崩れていないこと
- iPad（768x1024）縦持ち以上のwidthでレスポンシブにレイアウトが変わること
- 1200px以上でcontactの各種SNSが横並びになること
  - ipadサイズで揃えたかったのですが、どうにもきれいにならず若干中途半端ではあります。
  - 正直キリがないので妥協しました。

## 使い方

表示するだけです。
以下のサイズで確認しています。
- iPhone6/7/8系 = width:375px
- iPad最小サイズ = width:768px
- 1200px以上 = iPad Pro横持ち = width:1366px
- その他、ウィンドウサイズを適当に動かして表示が切り替わること。

## 今後の作業予定

jsに進みます。